### PR TITLE
Fix typo in compound 's forms: 'cU' -> 'Cu'

### DIFF
--- a/grae/grae.html
+++ b/grae/grae.html
@@ -169,9 +169,9 @@
                 <input name="Ga68-Dota-toc-lot-number" placeholder="Lot Number" disabled>
             </div>
             <div class="checkbox-label-input">
-                <input name="cU64-fbp8" type="checkbox">
+                <input name="Cu64-fbp8" type="checkbox">
                 <label>Cu64-FBP8</label>
-                <input name="cU64-fbp8-lot-number" placeholder="Lot Number" disabled>
+                <input name="Cu64-fbp8-lot-number" placeholder="Lot Number" disabled>
             </div>
             <div class="checkbox-label-input">
                 <input name="c11-diprenorphine" type="checkbox">

--- a/judit/judit.html
+++ b/judit/judit.html
@@ -100,9 +100,9 @@
                 <input name="Ga68-Dota-toc-lot-number" disabled>
             </div>
             <div class="checkbox-label-input">
-                <input name="cU64-fbp8" type="checkbox">
+                <input name="Cu64-fbp8" type="checkbox">
                 <label>Cu64-FBP8</label>
-                <input name="cU64-fbp8-lot-number" disabled>
+                <input name="Cu64-fbp8-lot-number" disabled>
             </div>
             <div class="checkbox-label-input">
                 <input name="c11-diprenorphine" type="checkbox">


### PR DESCRIPTION
The name was capitalized wrong in some of the labels.